### PR TITLE
use : and self plugin name for command/qualified names

### DIFF
--- a/npe2_tester/napari.yaml
+++ b/npe2_tester/napari.yaml
@@ -1,4 +1,4 @@
-name: my_plugin  # pypi package name (normalize to identifier)
+name: npe2_tester  # pypi package name (normalize to identifier)
 publisher: pub
 display_name: My Plugin
 license: BSD-3-Clause
@@ -7,14 +7,14 @@ contributes:
   # perhaps we exclude "my_plugin" and do the prefixing ourself
   # or just enforce on validation (probably this)
   commands:
-    - command: my_plugin.hello_world
+    - command: npe2_tester.hello_world
       title: Hello World
-    - command: my_plugin.another_command
+    - command: npe2_tester.another_command
       title: Another Command
-    - command: my_plugin.tiff_reader
+    - command: npe2_tester.tiff_reader
       title: My Tiff Reader
       python_name: npe2_tester:get_reader
-    - command: id...
+    - command:  npe2_tester.another_id
       title: "Image to Labels"
       enablement: 'active_layer_type == "image"'
     - command: my_plugin.affinder
@@ -25,14 +25,14 @@ contributes:
 
   configuration:  # call it settings?
     properties:
-      my_plugin.reader.lazy:
+      npe2_tester.reader.lazy:
         type: boolean
         default: false
         title: Load lazily
         description: Whether to load images lazily with dask
 
   readers:
-    - command: my_plugin.tiff_reader
+    - command: npe2_tester.tiff_reader
       filename_patterns: ["*.tif", "*.tiff"]
       accepts_directories: false
   writers:
@@ -49,7 +49,7 @@ contributes:
 
 
   keybindings:
-    - command: my_plugin.hello_world
+    - command: npe2_tester.hello_world
       key: ctrl+f1
   mousebindings:
     - command: ...


### PR DESCRIPTION
Commands looks like python fully qualified names, but are actually just identifiers, so leaving them alone.